### PR TITLE
Add GH actions

### DIFF
--- a/.github/scripts/ci.sh
+++ b/.github/scripts/ci.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+WORKDIR=${PWD}
+
+# Getting the ARM toolchain
+wget -qO- https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/RC2.1/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2 | tar -xj
+export PATH=${PWD}/gcc-arm-none-eabi-9-2019-q4-major/bin:$PATH
+
+# Create artifacts directory
+mkdir root boot
+
+# Build U-boot bootloader
+pushd u-boot-xlnx
+export ARCH=arm
+export CROSS_COMPILE=arm-none-eabi-
+make zynq_zybo_z7_defconfig
+make -j`nproc`
+
+cp spl/boot.bin u-boot.img ${WORKDIR}/boot
+popd
+
+# Build Linux kernel
+pushd linux-xlnx
+git apply ../linux/0001-Add-symbiflow-tester-driver.patch
+export ARCH=arm
+export CROSS_COMPILE=arm-none-eabi-
+export LOADADDR=0x8000
+make xilinx_zynq_defconfig
+make -j`nproc` uImage
+make -j`nproc` dtbs
+make -j`nproc` modules
+
+cp arch/arm/boot/uImage ${WORKDIR}/boot
+cp arch/arm/boot/dts/zynq-zybo-z7.dtb ${WORKDIR}/boot/devicetree.dtb
+cp drivers/misc/symbiflow-tester.ko ${WORKDIR}/root
+popd
+
+# Adding required files to rootfs
+cp -a python/symbiflow_test.py devmemX zynq_bootloader ${WORKDIR}/root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI artifacts generation
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+
+jobs:
+
+  Run-tests:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Install Dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y bzip2 make u-boot-tools
+
+    - name: Build Images
+      run: |
+        source .github/scripts/ci.sh
+        zip -r uboot-linux-images.zip root boot
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release xc7 automatic tester
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url  }}
+        asset_path: ./uboot-linux-images.zip
+        asset_name: uboot-linux-images.zip
+        asset_content_type: application/zip

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Building the kernel:
 
 ``` bash
 cd linux-xlnx
+git apply ../linux/0001-Add-symbiflow-tester-driver.patch
 export ARCH=arm
 export CROSS_COMPILE=arm-none-eabi-
 export LOADADDR=0x8000
@@ -91,7 +92,7 @@ Copy the required files to the SD card:
 ``` bash
 cp arch/arm/boot/uImage /path/to/mountpoint/boot
 cp arch/arm/boot/dts/zynq-zybo-z7.dtb /path/to/mountpoint/boot/devicetree.dtb
-sudo cp drivers/misci/symbiflow-tester.ko /path/to/mountpoint/rootfs/root
+sudo cp drivers/misc/symbiflow-tester.ko /path/to/mountpoint/rootfs/root
 ```
 
 ### Adding required files to rootfs
@@ -101,7 +102,7 @@ Copy the required files to the SD card:
 ``` bash
 sudo cp python/symbiflow_test.py /path/to/mountpoint/rootfs/root
 sudo cp -a devmemX /path/to/mountpoint/rootfs/root
-sudo cp -a zynq_bootloader /path/to/mountpoint/root
+sudo cp -a zynq_bootloader /path/to/mountpoint/rootfs/root
 ```
 
 ## Running the tests
@@ -114,7 +115,7 @@ Stop U-Boot autoboot by pressing any key during countdown.
 In U-Boot's console run the following commands:
 
 ```
-setenv booargs "root=/dev/mmcblk0p2 rw rootwait"
+setenv bootargs "root=/dev/mmcblk0p2 rw rootwait"
 setenv bootcmd "load mmc 0 0x1000000 uImage && load mmc 0 0x2000000 devicetree.dtb && bootm 0x1000000 - 0x2000000"
 saveenv
 ```

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ cp arch/arm/boot/dts/zynq-zybo-z7.dtb /path/to/mountpoint/boot/devicetree.dtb
 sudo cp drivers/misc/symbiflow-tester.ko /path/to/mountpoint/rootfs/root
 ```
 
+
 ### Adding required files to rootfs
 
 Copy the required files to the SD card:


### PR DESCRIPTION
This PR does the following:

- adds GH actions to run and build all the Linux and U-boot images and upload them as artifacts (probably it is better to have a release to have them not expiring, and have a static link)
- fixes some typos in the README

Link to the latest GH build: https://github.com/antmicro/symbiflow-xc7z-automatic-tester/actions/runs/428251111