### PR TITLE
Gh action license check

### DIFF
--- a/.github/scripts/ci.sh
+++ b/.github/scripts/ci.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (C) 2020-2021  The Project X-Ray Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
 
 WORKDIR=${PWD}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
-name: CI artifacts generation
+# Copyright (C) 2020-2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:ISC
 
-on:
-  push:
-    tags:
-      - 'v*'
+name: CI tests
 
+on: [push, pull_request]
 
 jobs:
 
@@ -13,39 +17,5 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-      with:
-        submodules: recursive
 
     - uses: SymbiFlow/actions/checks@main
-
-    - name: Install Dependencies
-      run: |
-        sudo apt update
-        sudo apt install -y bzip2 make u-boot-tools
-
-    - name: Build Images
-      run: |
-        source .github/scripts/ci.sh
-        zip -r uboot-linux-images.zip root boot
-
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release xc7 automatic tester
-        draft: false
-        prerelease: false
-
-    - name: Upload Release Asset
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url  }}
-        asset_path: ./uboot-linux-images.zip
-        asset_name: uboot-linux-images.zip
-        asset_content_type: application/zip

--- a/.github/workflows/release.ci.yml
+++ b/.github/workflows/release.ci.yml
@@ -1,3 +1,11 @@
+# Copyright (C) 2020-2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:ISC
+#
 name: CI artifacts generation
 
 on:

--- a/.github/workflows/release.ci.yml
+++ b/.github/workflows/release.ci.yml
@@ -1,0 +1,51 @@
+name: CI artifacts generation
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+
+jobs:
+
+  Run-tests:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - uses: SymbiFlow/actions/checks@main
+
+    - name: Install Dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y bzip2 make u-boot-tools
+
+    - name: Build Images
+      run: |
+        source .github/scripts/ci.sh
+        zip -r uboot-linux-images.zip root boot
+
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release xc7 automatic tester
+        draft: false
+        prerelease: false
+
+    - name: Upload Release Asset
+      id: upload-release-asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN  }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url  }}
+        asset_path: ./uboot-linux-images.zip
+        asset_name: uboot-linux-images.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
Add a separate GH actions workflow that performs the license check using the `symbiflow/actions/checks@main` action.
Addresses issue #5.